### PR TITLE
Fix cleaning up with non existing path

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -165,5 +165,6 @@
     file:
       path: "{{ container_pod_yaml }}"
       state: absent
+    when: container_pod_yaml is defined
 
   when: container_state == "absent"


### PR DESCRIPTION
If container_pod_yaml is not defined, we were failing to provide a path to the file module.

Fixes: #1