### PR TITLE
Add container_cmd_args option for single containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ note that some options apply only to other method.
   Systemd service file be named container_name--container-pod.service.
 - ```container_run_args``` - Anything you pass to podman, except for the name
   and image while running single container. Not used for pod.
+- ```container_cmd_args``` - Any command and arguments passed to podman-run after specifying the image name. Not used for pod.
 - ```container_run_as_user``` - Which user should systemd run container as.
   Defaults to root.
 - ```container_run_as_group``` - Which grou should systemd run container as.

--- a/templates/systemd-service-single.j2
+++ b/templates/systemd-service-single.j2
@@ -11,7 +11,8 @@ User={{ container_run_as_user }}
 ExecStart=/usr/bin/podman run --name {{ container_name }} \
   {{ container_run_args }} \
   --conmon-pidfile  /%T/%n-pid --cidfile /%T/%n-cid \
-  {{ container_image }}
+  {{ container_image }} \
+  {{ container_cmd_args }}
 
 ExecStop=/usr/bin/sh -c "/usr/bin/podman stop -t "{{ container_stop_timeout }}" `cat /%T/%n-cid`"
 ExecStop=/usr/bin/sh -c "/usr/bin/podman rm -f `cat /%T/%n-cid`"


### PR DESCRIPTION
* container_run_args provide all flags for podman-run(1)
* container_cmd_args can be used complementary for providing
  a cmd and it's args after specifying the image

e.g. podman run --name certbot --rm -v ... docker.io/certbot/certbot \
            certonly --webroot --webroot-path=/usr/share/nginx/html \
            -d exmaple.com

Fixes: #6