### PR TITLE
add option "-t" to lighttpd container fixing Permission denied error in latest lighttpd container

### DIFF
--- a/templates/systemd-service-single.j2
+++ b/templates/systemd-service-single.j2
@@ -5,21 +5,21 @@ After=network.target
 [Service]
 Type=simple
 TimeoutStartSec={{ systemd_TimeoutStartSec }}
-ExecStartPre=-/usr/bin/rm -f /%T/%n-pid /%T/%n-cid
+ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
 User={{ container_run_as_user }}
 
 ExecStart=/usr/bin/podman run --name {{ container_name }} \
   {{ container_run_args }} \
-  --conmon-pidfile  /%T/%n-pid --cidfile /%T/%n-cid \
+  --conmon-pidfile  /%t/%n-pid --cidfile /%t/%n-cid \
   {{ container_image }} {% if container_cmd_args is defined %} \
   {{ container_cmd_args }} {% endif %}
 
-ExecStop=/usr/bin/sh -c "/usr/bin/podman stop -t "{{ container_stop_timeout }}" `cat /%T/%n-cid`"
-ExecStop=/usr/bin/sh -c "/usr/bin/podman rm -f `cat /%T/%n-cid`"
+ExecStop=/usr/bin/sh -c "/usr/bin/podman stop -t "{{ container_stop_timeout }}" `cat /%t/%n-cid`"
+ExecStop=/usr/bin/sh -c "/usr/bin/podman rm -f `cat /%t/%n-cid`"
 Restart={{ container_restart }}
 RestartSec={{ systemd_RestartSec }}
 KillMode=none
-PIDFile=/%T/%n-pid
+PIDFile=/%t/%n-pid
 
 [Install]
 WantedBy=multi-user.target

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -32,6 +32,7 @@
         --rm
         -v /tmp/podman-container-systemd:/var/www/localhost/htdocs:Z
         -p 8080:80/tcp
+        -t
       container_firewall_ports:
         - 8080/tcp
 


### PR DESCRIPTION
add option "-t" to lighttpd container to use pseudo tty in order to fix the error "(server.c.748) opening errorlog '/dev/pts/0' failed: Permission denied"

see also: https://github.com/spujadas/lighttpd-docker/issues/8