### PR TITLE
non-root fixes

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,16 +20,20 @@
 
   - name: check if user is in subuid file
     lineinfile:
+      line: '\1'
       path: /etc/subuid
-      regexp: "^{{ container_run_as_user }}:.*"
+      regexp: "^({{ container_run_as_user }}:.*)"
+      backrefs: yes
     check_mode: yes
     register: uid_has
     ignore_errors: true
 
   - name: check if group is in subgid file
     lineinfile:
+      line: '\1'
       path: /etc/subgid
-      regexp: "^{{ container_run_as_group }}:.*"
+      regexp: "^({{ container_run_as_group }}:.*)"
+      backrefs: yes
     check_mode: yes
     register: gid_has
     ignore_errors: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,6 +27,7 @@
     check_mode: yes
     register: uid_has
     ignore_errors: true
+    when: container_run_as_user != 'root'
 
   - name: check if group is in subgid file
     lineinfile:
@@ -37,6 +38,7 @@
     check_mode: yes
     register: gid_has
     ignore_errors: true
+    when: container_run_as_group != 'root'
 
   - name: ensure user is in subuid file, if it was missing
     lineinfile:
@@ -58,7 +60,7 @@
       mode: '0644'
       owner: root
       group: root
-    when: gid_has.changed and container_run_as_user != 'root'
+    when: gid_has.changed and container_run_as_group != 'root'
 
   - name: running single container, get image Id if it exists and we are root
     # XXX podman doesn't work through sudo for non root users, so skip preload if user


### PR DESCRIPTION
- fix error message 'fatal: [host]: FAILED! => {"changed": false, "msg": "line is required with state=present"}' by using backrefs to recreate the original line
- Added when statement for the subuid and subgid checks which do not run the check is the user or group is root
- Fix bug, container_run_as_user was used in the when statement instead of container_run_as_group for /etc/subgid