### PR TITLE
Conditionally set cid- and pidfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ note that some options apply only to other method.
   and want to open firewall for. When container_state is absent, firewall ports
   get closed. If you don't want firewalld installed, don't define this.
 - ```systemd_TimeoutStartSec``` - how long does systemd wait for container to start?
+- ```systemd_tempdir``` - Where to store conmon-pidfile and cidfile for single containers.
+  Defaults to ``%T`` on systems supporting this specifier (see man 5 systemd.unit) ``/tmp``
+  otherwise.
 
 This playbook doesn't have python module to parse parameters for podman command.
 Until that you just need to pass all parameters as you would use podman from

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,8 @@ container_restart: on-failure
 service_files_dir: /etc/systemd/system
 systemd_TimeoutStartSec: 15
 systemd_RestartSec: 30
+systemd_tempdir: "{{ '/tmp' if ansible_os_family == 'RedHat' and
+  ansible_distribution_major_version|int == 7 else '%T' }}"
 container_run_as_user: root
 container_run_as_group: root
 container_stop_timeout: 15

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,6 +8,10 @@ galaxy_info:
   - name: Fedora
     versions:
     - all
+  - name: EL
+    versions:
+    - 7
+    - 8
   galaxy_tags:
   - podman
   - container

--- a/templates/systemd-service-single.j2
+++ b/templates/systemd-service-single.j2
@@ -5,21 +5,21 @@ After=network.target
 [Service]
 Type=simple
 TimeoutStartSec={{ systemd_TimeoutStartSec }}
-ExecStartPre=-/usr/bin/rm -f /%T/%n-pid /%T/%n-cid
+ExecStartPre=-/usr/bin/rm -f {{ pidfile }} {{ cidfile }}
 User={{ container_run_as_user }}
 
 ExecStart=/usr/bin/podman run --name {{ container_name }} \
   {{ container_run_args }} \
-  --conmon-pidfile  /%T/%n-pid --cidfile /%T/%n-cid \
+  --conmon-pidfile  {{ pidfile }} --cidfile {{ cidfile }} \
   {{ container_image }} {% if container_cmd_args is defined %} \
   {{ container_cmd_args }} {% endif %}
 
-ExecStop=/usr/bin/sh -c "/usr/bin/podman stop -t "{{ container_stop_timeout }}" `cat /%T/%n-cid`"
-ExecStop=/usr/bin/sh -c "/usr/bin/podman rm -f `cat /%T/%n-cid`"
+ExecStop=/usr/bin/sh -c "/usr/bin/podman stop -t "{{ container_stop_timeout }}" `cat {{ cidfile }}`"
+ExecStop=/usr/bin/sh -c "/usr/bin/podman rm -f `cat {{ cidfile }}`"
 Restart={{ container_restart }}
 RestartSec={{ systemd_RestartSec }}
 KillMode=none
-PIDFile=/%T/%n-pid
+PIDFile={{ pidfile }}
 
 [Install]
 WantedBy=multi-user.target

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,3 +2,6 @@
 
 # systemd service name
 service_name: "{{ container_name }}-container-pod.service"
+cidpid_base: "{{ systemd_tempdir }}/%n-"
+cidfile: "{{ cidpid_base }}cid"
+pidfile: "{{ cidpid_base }}pid"


### PR DESCRIPTION
I am using this role on EL 7 and 8.

On EL 7 ``%T`` is not supported by systemd.unit
whereas ``%t`` is supported.

Therefore I propose to use ``%t`` on EL7.

I remember a thread where you (@ikke-t) discussed why he changed form ``%t`` to ``%T``. Nevertheless this fix is just applied on el7 and the default is unchanged.

Best
Christian