### PR TITLE
Allow to run on Debian buster and Ubuntu

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,3 +21,8 @@ container_stop_timeout: 15
 
 # to sepped up you can disable always checking if podman is installed.
 skip_podman_install: true
+
+podman_dependencies_rootless:
+  - fuse-overlayfs
+  - slirp4netns
+  - uidmap

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,6 +7,9 @@ galaxy_info:
   license: GPLv3
   min_ansible_version: 2.4
   platforms:
+    - name: Debian
+      versions:
+        - 10
     - name: EL
       versions:
         - 8
@@ -19,4 +22,9 @@ galaxy_info:
     - container
     - systemd
 
-dependencies: []
+dependencies:
+  - role: systemli.apt_repositories
+    vars:
+      apt_repositories:
+        - preset: kubic
+    when: ansible_distribution == 'Debian' and ansible_distribution_release == 'buster'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,6 +17,12 @@ galaxy_info:
     - name: Fedora
       versions:
         - all
+    - name: Ubuntu
+      versions:
+        - 18.04
+        - 19.04
+        - 19.10
+        - 20.04
   galaxy_tags:
     - podman
     - container
@@ -27,4 +33,5 @@ dependencies:
     vars:
       apt_repositories:
         - preset: kubic
-    when: ansible_distribution == 'Debian' and ansible_distribution_release == 'buster'
+    when: (ansible_distribution == 'Debian' and ansible_distribution_release == 'buster') or
+          ansible_distribution == 'Ubuntu'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,11 +17,11 @@
       sysctl_set: true
     when: ansible_distribution == 'Debian'
 
-  - name: Install rootless dependencies
+  - name: Install rootless dependencies on Debian-based
     package:
       name: "{{ podman_dependencies_rootless }}"
       state: present
-    when: container_run_as_user != 'root'
+    when: ansible_os_family == 'Debian' and container_run_as_user != 'root'
 
   - name: ensure podman is installed
     package:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,10 +8,25 @@
 - name: do tasks when "{{ service_name }}" state is "running"
   block:
 
+  - name: Allow unprivileged users on Debian
+    sysctl:
+      name: kernel.unprivileged_userns_clone
+      value: '1'
+      state: present
+      sysctl_file: /etc/sysctl.d/userns.conf
+      sysctl_set: true
+    when: ansible_distribution == 'Debian'
+
+  - name: Install rootless dependencies
+    package:
+      name: "{{ podman_dependencies_rootless }}"
+      state: present
+    when: container_run_as_user != 'root'
+
   - name: ensure podman is installed
     package:
       name: podman
-      state: installed
+      state: present
     when: not skip_podman_install
 
   - name: check user exists
@@ -176,7 +191,7 @@
 
   - name: ensure firewalld is installed
     tags: firewall
-    package: name=firewalld state=installed
+    package: name=firewalld state=present
 
   - name: ensure firewall service is running
     tags: firewall


### PR DESCRIPTION
* Allow to install packages from project kubic
* Install dependencies when rootless

The examples in `README.md` are failing for me, but I think this is a problem specific to the lighttpd image.