### PR TITLE
Check if unprivileged_userns_clone is supported by kernel before runn…

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,12 @@
 - name: do tasks when "{{ service_name }}" state is "running"
   block:
 
+  - name: Check for user namespace support in kernel
+    state:
+      path: /proc/sys/kernel/unprivileged_userns_clone
+    register: unprivileged_userns_clone
+    changed_when: false
+
   - name: Allow unprivileged users on Debian
     sysctl:
       name: kernel.unprivileged_userns_clone
@@ -15,7 +21,7 @@
       state: present
       sysctl_file: /etc/sysctl.d/userns.conf
       sysctl_set: true
-    when: ansible_distribution == 'Debian'
+    when: ansible_distribution == 'Debian' and unprivileged_userns_clone.stat.exists
 
   - name: Install rootless dependencies on Debian-based
     package:


### PR DESCRIPTION
With raspbian kernel this task would fail:

> TASK [podman_container_systemd : Allow unprivileged users on Debian] > ***************************************************************************************************************************************
> fatal: [XXX]: FAILED! => {"changed": false, "msg": "Failed to reload sysctl: sysctl: cannot stat /proc/sys/kernel/unprivileged_userns_clone: No such file or directory\n"}

This merge request is adding a check for this kernel parameter before performing the sysctl task.
