### PR TITLE
Fix typo.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
   block:
 
   - name: Check for user namespace support in kernel
-    state:
+    stat:
       path: /proc/sys/kernel/unprivileged_userns_clone
     register: unprivileged_userns_clone
     changed_when: false


### PR DESCRIPTION
Fix the typo (`state` instead of `stat` command) introduced in the previous merge request.