### PR TITLE
Changes to support rootless containers

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -84,38 +84,36 @@
     when: gid_has.changed and container_run_as_group != 'root'
 
   - name: running single container, get image Id if it exists and we are root
-    # XXX podman doesn't work through sudo for non root users, so skip preload if user
-    # https://github.com/containers/libpod/issues/5570
-    # command: podman inspect -f {{.Id}} "{{ container_image }}"
     command: "podman image inspect -f '{{ '{{' }}.Id{{ '}}' }}' {{ container_image }}"
+    changed_when: false
+    become: yes
+    become_user: "{{ container_run_as_user }}"
     register: pre_pull_id
     ignore_errors: yes
-    when: container_image is defined and container_run_as_user == 'root'
+    when: container_image is defined
 
   - name: running single container, ensure we have up to date container image
     command: "podman pull {{ container_image }}"
     become: yes
     become_user: "{{ container_run_as_user }}"
-    when: container_image is defined and container_run_as_user == 'root'
+    when: container_image is defined
 
   - name: running single container, get image Id if it exists
     command: "podman image inspect -f '{{ '{{' }}.Id{{ '}}' }}'  {{ container_image }}"
+    changed_when: false
     become: yes
     become_user: "{{ container_run_as_user }}"
     register: post_pull_id
-    when: container_image is defined and container_run_as_user == 'root'
+    when: container_image is defined
 
   - name: force restart after image change
     debug: msg="image has changed"
     changed_when: True
     notify: restart service
     when:
-      - container_run_as_user == 'root'
       - container_image is defined
       - pre_pull_id.stdout != post_pull_id.stdout
       - pre_pull_id is succeeded
-
-  # XXX remove above comparison if future podman tells image changed.
 
   - name: seems we use several container images, ensure all are up to date
     command: "podman pull {{ item }}"
@@ -140,8 +138,8 @@
     template:
       src: systemd-service-single.j2
       dest: "{{ service_files_dir }}/{{ service_name }}"
-      owner: root
-      group: root
+      owner: "{{ container_run_as_user }}"
+      group: "{{ container_run_as_group }}"
       mode: 0644
     notify: reload systemctl
     register: service_file
@@ -151,8 +149,8 @@
     template:
       src: systemd-service-pod.j2
       dest: "{{ service_files_dir }}/{{ service_name }}"
-      owner: root
-      group: root
+      owner: "{{ container_run_as_user }}"
+      group: "{{ container_run_as_group }}"
       mode: 0644
     notify:
       - reload systemctl
@@ -161,8 +159,11 @@
     when: container_image_list is defined
 
   - name: ensure "{{ service_name }}" is enabled at boot, and systemd reloaded
+    become: yes
+    become_user: "{{ container_run_as_user }}"
     systemd:
       name: "{{ service_name }}"
+      scope: "{{ 'system' if container_run_as_user == 'root' else 'user' }}"
       enabled: yes
       daemon_reload: yes
 
@@ -173,6 +174,8 @@
     when: not service_file_before_template.stat.exists
 
   - name: "ensure {{ service_name }} is restarted due config change"
+    become: yes
+    become_user: "{{ container_run_as_user }}"
     debug: msg="config has changed:"
     changed_when: True
     notify: restart service

--- a/templates/systemd-service-pod.j2
+++ b/templates/systemd-service-pod.j2
@@ -6,7 +6,6 @@ After=network.target
 Type=forking
 TimeoutStartSec={{ systemd_TimeoutStartSec }}
 ExecStartPre=-/usr/bin/podman pod rm -f {{ container_name }}
-User={{ container_run_as_user }}
 RemainAfterExit=yes
 
 ExecStart=/usr/bin/podman play kube {{ container_pod_yaml }}

--- a/templates/systemd-service-single.j2
+++ b/templates/systemd-service-single.j2
@@ -6,10 +6,10 @@ After=network.target
 Type=simple
 TimeoutStartSec={{ systemd_TimeoutStartSec }}
 ExecStartPre=-/usr/bin/rm -f {{ pidfile }} {{ cidfile }}
-User={{ container_run_as_user }}
 
 ExecStart=/usr/bin/podman run --name {{ container_name }} \
   {{ container_run_args }} \
+  -d --cgroups=no-conmon --replace \
   --conmon-pidfile  {{ pidfile }} --cidfile {{ cidfile }} \
   {{ container_image }} {% if container_cmd_args is defined %} \
   {{ container_cmd_args }} {% endif %}
@@ -22,4 +22,4 @@ KillMode=none
 PIDFile={{ pidfile }}
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=multi-user.target default.target

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -5,3 +5,6 @@ service_name: "{{ container_name }}-container-pod.service"
 cidpid_base: "{{ systemd_tempdir }}/%n-"
 cidfile: "{{ cidpid_base }}cid"
 pidfile: "{{ cidpid_base }}pid"
+root_service_dir: '/etc/systemd/system'
+user_service_dir: "/home/{{ container_run_as_user }}/.config/systemd/user"
+service_files_dir: "{{ root_service_dir if container_run_as_user == 'root' else user_service_dir }}"


### PR DESCRIPTION
This allows rootless containers to run in user service manager.
Root containers will continue to run in system manager.

This fixes a bug where the PID for a rootless container can't be managed by system when using podman 2.0.5 and cgroupsv2

https://github.com/ikke-t/podman-container-systemd/issues/4#issuecomment-684788654