### PR TITLE
Use only `container_image_list` and remove `container_image` variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,8 @@ Role uses variables that are required to be passed while including it. As
 there is option to run one container separately or multiple containers in pod,
 note that some options apply only to other method.
 
-- ```container_image``` - container image and tag, e.g. nextcloud:latest
-  This is used only if you run single container
-- ```container_image_list``` - list of container images to run within a pod.
-  This is used only if you run containers in pod.
+- ```container_image_list``` - list of container images to run.
+  If more than one image is defined, then the containers will be run in a pod.
 - ```container_name``` - Identify the container in systemd and podman commands.
   Systemd service file be named container_name--container-pod.service.
 - ```container_run_args``` - Anything you pass to podman, except for the name
@@ -105,7 +103,7 @@ Root container:
 ```
 - name: tests container
   vars:
-    container_image: sebp/lighttpd:latest
+    container_image_list: sebp/lighttpd:latest
     container_name: lighttpd
     container_run_args: >-
       --rm
@@ -139,7 +137,7 @@ Rootless container:
   vars:
     container_run_as_user: rootless_user
     container_run_as_group: rootless_user
-    container_image: sebp/lighttpd:latest
+    container_image_list: sebp/lighttpd:latest
     container_name: lighttpd
     container_run_args: >-
       --rm

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ Root container:
 ```
 - name: tests container
   vars:
-    container_image_list: sebp/lighttpd:latest
+    container_image_list: 
+      - sebp/lighttpd:latest
     container_name: lighttpd
     container_run_args: >-
       --rm
@@ -137,7 +138,8 @@ Rootless container:
   vars:
     container_run_as_user: rootless_user
     container_run_as_group: rootless_user
-    container_image_list: sebp/lighttpd:latest
+    container_image_list: 
+      - sebp/lighttpd:latest
     container_name: lighttpd
     container_run_args: >-
       --rm

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -93,11 +93,11 @@
     when: container_image_list is defined and container_image_list | length == 1 and container_run_as_user == 'root'
     with_items: "{{ container_image_list }}"
 
-  - name: seems we use several container images, ensure all are up to date
+  - name: running single container, ensure we have up to date container image
     command: "podman pull {{ item }}"
     become: yes
     become_user: "{{ container_run_as_user }}"
-    when: container_image_list is defined and container_image_list | length > 0
+    when: container_image_list is defined and container_image_list | length == 1
     with_items: "{{ container_image_list }}"
 
   - name: running single container, get image Id if it exists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -87,23 +87,25 @@
     # XXX podman doesn't work through sudo for non root users, so skip preload if user
     # https://github.com/containers/libpod/issues/5570
     # command: podman inspect -f {{.Id}} "{{ container_image }}"
-    command: "podman image inspect -f '{{ '{{' }}.Id{{ '}}' }}' {{ container_image }}"
+    command: "podman image inspect -f '{{ '{{' }}.Id{{ '}}' }}' {{ item }}"
     register: pre_pull_id
     ignore_errors: yes
-    when: container_image is defined and container_run_as_user == 'root'
+    when: container_image_list is defined and container_image_list | length == 1 and container_run_as_user == 'root'
+    with_items: "{{ container_image_list }}"
 
-  - name: running single container, ensure we have up to date container image
-    command: "podman pull {{ container_image }}"
+  - name: seems we use several container images, ensure all are up to date
+    command: "podman pull {{ item }}"
     become: yes
     become_user: "{{ container_run_as_user }}"
-    when: container_image is defined and container_run_as_user == 'root'
+    when: container_image_list is defined and container_image_list | length > 0
+    with_items: "{{ container_image_list }}"
 
   - name: running single container, get image Id if it exists
-    command: "podman image inspect -f '{{ '{{' }}.Id{{ '}}' }}'  {{ container_image }}"
-    become: yes
-    become_user: "{{ container_run_as_user }}"
+    command: "podman image inspect -f '{{ '{{' }}.Id{{ '}}' }}' {{ item }}"
     register: post_pull_id
-    when: container_image is defined and container_run_as_user == 'root'
+    ignore_errors: yes
+    when: container_image_list is defined and container_image_list | length == 1 and container_run_as_user == 'root'
+    with_items: "{{ container_image_list }}"
 
   - name: force restart after image change
     debug: msg="image has changed"
@@ -111,7 +113,8 @@
     notify: restart service
     when:
       - container_run_as_user == 'root'
-      - container_image is defined
+      - ontainer_image_list is defined
+      - container_image_list | length == 1
       - pre_pull_id.stdout != post_pull_id.stdout
       - pre_pull_id is succeeded
 
@@ -121,7 +124,7 @@
     command: "podman pull {{ item }}"
     become: yes
     become_user: "{{ container_run_as_user }}"
-    when: container_image_list is defined
+    when: container_image_list is defined and container_image_list | length > 1
     with_items: "{{ container_image_list }}"
 
   - name: if running pod, ensure configuration file exists
@@ -145,7 +148,7 @@
       mode: 0644
     notify: reload systemctl
     register: service_file
-    when: container_image is defined
+    when: container_image_list is defined and container_image_list | length == 1
 
   - name: "create systemd service file for pod: {{ container_name }}"
     template:
@@ -158,7 +161,7 @@
       - reload systemctl
       - start service
     register: service_file
-    when: container_image_list is defined
+    when: container_image_list is defined and container_image_list | length > 1
 
   - name: ensure "{{ service_name }}" is enabled at boot, and systemd reloaded
     systemd:

--- a/templates/systemd-service-single.j2
+++ b/templates/systemd-service-single.j2
@@ -11,7 +11,7 @@ User={{ container_run_as_user }}
 ExecStart=/usr/bin/podman run --name {{ container_name }} \
   {{ container_run_args }} \
   --conmon-pidfile  {{ pidfile }} --cidfile {{ cidfile }} \
-  {{ container_image }} {% if container_cmd_args is defined %} \
+  {{ container_image_list | first }} {% if container_cmd_args is defined %} \
   {{ container_cmd_args }} {% endif %}
 
 ExecStop=/usr/bin/sh -c "/usr/bin/podman stop -t "{{ container_stop_timeout }}" `cat {{ cidfile }}`"


### PR DESCRIPTION
This PR consolidates on using only the variable `container_image_list`, rather than the existing split between `container_image_list` and `container_image` when working with pods and standalone containers, respectively.

Actions for pods/standalone is done by testing the length of the list instead. This prevents an issue resulting in unintended behaviour where both `container_image_list` and `container_image` are both set.

Removal of `container_image` is a breaking change.

Resolves #22 

**Note: I have not tested this code at all.**