### PR TITLE
Use full path for firewalld module

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,4 @@
 ---
 collections:
+  - ansible.posix
   - containers.podman

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -259,7 +259,7 @@
 
   - name: ensure container's exposed ports firewall state
     tags: firewall
-    firewalld:
+    ansible.posix.firewalld:
       port: "{{ item }}"
       permanent: true
       immediate: true


### PR DESCRIPTION
On more recent versions of Ansible this roles hits an error, due to firewalld being removed from the built in modules.

```
ERROR! couldn't resolve module/action 'firewalld'. This often indicates a misspelling, missing collection, or incorrect module path.

The error appears to be in '/home/user/.ansible/roles/podman_container_systemd/tasks/main.yml': line 248, column 5, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


  - name: ensure container's exposed ports firewall state
    ^ here
```