### PR TITLE
Add missing dep in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Dependencies
 ------------
 
 * [containers.podman](https://galaxy.ansible.com/containers/podman) (collection)
+* [ansible.posix](https://galaxy.ansible.com/ansible/posix) (collection)
 
 Example Playbook
 ----------------


### PR DESCRIPTION
Hello,

I added `ansible.posix` collection as dependency in README.

Cheers,
jcapitao