### PR TITLE
Install podman by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,7 +21,7 @@ container_stop_timeout: 15
 service_name: "{{ container_name }}-container-pod-{{ container_run_as_user }}.service"
 
 # to sepped up you can disable always checking if podman is installed.
-skip_podman_install: true
+skip_podman_install: false
 
 podman_dependencies_rootless:
   - fuse-overlayfs


### PR DESCRIPTION
I think it'd be better to install podman by default.
Then, as mentioned in the comment, the user can disable it to speed up deployment after first shot.

When running the playbook the first time in a freshly built CentOS Stream 8 instance, the deployment failed at task `[ensure auto update is running for image]`, because `podman` is not installed (i.e systemd file `podman-auto-update.timer` not available)

Cheers
jcapitao