### PR TITLE
fix: use /usr/local/lib/systemd/system/ as default path

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@ container_state: running
 # see man systemd.service for info
 # by default we want to restart failed container
 container_restart: on-failure
-service_files_dir: /etc/systemd/system
+service_files_dir: /usr/local/lib/systemd/system
 systemd_scope: system
 systemd_TimeoutStartSec: 15
 systemd_RestartSec: 30

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,10 +38,19 @@
 - name: set systemd scope to system if needed
   set_fact:
     systemd_scope: system
-    service_files_dir: '/etc/systemd/system'
+    service_files_dir: /usr/local/lib/systemd/system
     xdg_runtime_dir: "/run/user/{{ container_run_as_uid.stdout }}"
   when: container_run_as_user == "root"
   changed_when: false
+
+- name: create local systemd directory
+  when: service_files_dir == '/usr/local/lib/systemd/system'
+  file:
+    group: root
+    mode: u=rwX,go=rX
+    owner: root
+    path: /usr/local/lib/systemd/system/
+    state: directory
 
 - name: check if service file exists already
   stat:


### PR DESCRIPTION
By using this path, local systemd configuration files are stored in the explicit local path. Then, when enabling them with the `systemd` module, what you will find under `/etc/systemd/system` automatically will be a symlink.

This helps keeping local stuff more organized.