### PR TITLE
fix: remove container before starting

### DIFF
--- a/templates/systemd-service-single.j2
+++ b/templates/systemd-service-single.j2
@@ -5,6 +5,8 @@ After=network.target
 [Service]
 Type=simple
 TimeoutStartSec={{ systemd_TimeoutStartSec }}
+ExecStartPre=-/usr/bin/podman stop -t {{ container_stop_timeout|quote }} {{ container_name|quote }}
+ExecStartPre=-/usr/bin/podman rm -f {{ container_name|quote }}
 ExecStartPre=-/usr/bin/rm -f {{ pidfile }} {{ cidfile }}
 {% if container_run_as_user == 'root' %}
 User={{ container_run_as_user }}


### PR DESCRIPTION
After running the role to start a service, I get these logs in loop:

```
Aug 08 07:09:57 rpi4test systemd[1]: Starting mando-traefik Podman Container...
Aug 08 07:09:57 rpi4test systemd[1]: Started mando-traefik Podman Container.
Aug 08 07:09:57 rpi4test podman[16458]: Error: error creating container storage: the container name "mando-traefik" is already in use by "cf78da2cb108e5c0389bd7a99f8d27fe9dd94284a14e33ead5481b2ef3683c7b". You have to remove that container to be able
 to reuse that name.: that name is already in use
Aug 08 07:09:57 rpi4test systemd[1]: mando-traefik.service: Main process exited, code=exited, status=125/n/a
Aug 08 07:09:57 rpi4test systemd[1]: mando-traefik.service: Failed with result 'exit-code'.
Aug 08 07:10:27 rpi4test systemd[1]: mando-traefik.service: Scheduled restart job, restart counter is at 2.
Aug 08 07:10:27 rpi4test systemd[1]: Stopped mando-traefik Podman Container.
```

This fixes the problem by always making sure the container is removed before start.