### PR TITLE
docs: warn about not using import_role

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ If you want your
 [images to be automatically updated](http://docs.podman.io/en/latest/markdown/podman-auto-update.1.html),
 add this label to container_cmd_args: ```--label "io.containers.autoupdate=image"```
 
+Never use `ansible.builtin.import_role` to execute this role if you intend to use it more
+than once per playbook, or you will fall in
+[this anti-pattern](https://medium.com/opsops/ansible-anti-pattern-import-role-task-with-task-level-vars-a9f5c752c9c3).
+
 Dependencies
 ------------
 
@@ -123,7 +127,7 @@ Root container:
     container_firewall_ports:
       - 8080/tcp
       - 8443/tcp
-  import_role:
+  ansible.builtin.include_role:
     name: podman-container-systemd
 ```
 
@@ -158,7 +162,7 @@ Rootless container:
     container_firewall_ports:
       - 8080/tcp
       - 8443/tcp
-  import_role:
+  ansible.builtin.include_role:
     name: podman-container-systemd
 ```
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -41,7 +41,7 @@
       container_firewall_ports:
         - 8080/tcp
 
-    import_role:
+    ansible.builtin.include_role:
       name: podman-container-systemd
 
   - name: Wait for lighttpd to come up


### PR DESCRIPTION
I was becoming crazy when trying to setup various services with various calls to this role.

It turns out there's an anti-pattern that is very well explained in https://medium.com/opsops/ansible-anti-pattern-import-role-task-with-task-level-vars-a9f5c752c9c3 and makes playbooks behave crazy.

Warn about it.