### PR TITLE
Fix systemd scope for rootful units.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,7 +38,7 @@
 - name: set systemd scope to system if needed
   set_fact:
     systemd_scope: system
-    service_files_dir: /usr/local/lib/systemd/system
+    service_files_dir: "{{ service_files_dir }}"
     xdg_runtime_dir: "/run/user/{{ container_run_as_uid.stdout }}"
   when: container_run_as_user == "root"
   changed_when: false


### PR DESCRIPTION
``service_files_dir`` may be overwritten
use variable here though