### PR TITLE
Tests loop over include_role

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,13 +44,14 @@
   changed_when: false
 
 - name: create local systemd directory
-  when: service_files_dir == '/usr/local/lib/systemd/system'
   file:
     group: root
     mode: u=rwX,go=rX
     owner: root
     path: /usr/local/lib/systemd/system/
     state: directory
+  become: true
+  when: container_run_as_user == "root" and service_files_dir == '/usr/local/lib/systemd/system'
 
 - name: check if service file exists already
   stat:
@@ -186,6 +187,8 @@
       owner: root
       group: root
       mode: 0644
+    become: true
+    become_user: "{{ container_run_as_user }}"
     notify:
       - reload systemctl
       - start service
@@ -245,6 +248,7 @@
   - name: ensure firewalld is installed
     tags: firewall
     package: name=firewalld state=present
+    become: true
     when: ansible_pkg_mgr != "atomic_container"
 
   - name: ensure firewalld is installed (on fedora-iot)
@@ -275,6 +279,7 @@
       permanent: true
       immediate: true
       state: "{{ fw_state }}"
+    become: true
     with_items: "{{ container_firewall_ports }}"
 
   - name: Force all notified handlers to run at this point
@@ -317,6 +322,7 @@
     file:
       path: "{{ service_files_dir }}/{{ service_name }}"
       state: absent
+    become: true
     notify: reload systemctl
 
   - name: Force all notified handlers to run at this point

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -14,7 +14,8 @@
   # connection: local
   # delegate_to: localhost
   vars:
-
+    container_state: running
+#    container_state: absent
   tasks:
   - name: create test dir for www file
     file:
@@ -28,8 +29,6 @@
 
   - name: tests container
     vars:
-      container_state: running
-      # container_state: absent
       container_image_list:
         - sebp/lighttpd:latest
       container_name: lighttpd

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -73,6 +73,9 @@
   - debug:
       msg:
         - "Got http://localhost:8080 to test if it worked!"
-        - "This sould state 'file' on success: {{ get_url.state }}"
+        - "This should state 'file' on success: {{ get_url.results[idx].state }}"
         - "On success, output should say 'Hello world!' here: {{ curl.stdout }}"
+    loop: "{{ container_instances }}"
+    loop_control:
+      index_var: idx
     when: container_state == "running"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -16,6 +16,11 @@
   vars:
     container_state: running
 #    container_state: absent
+    container_instances:
+      - name: lighthttpd-1
+        port: 8080
+      - name: lighthttpd-2
+        port: 8081
   tasks:
   - name: create test dir for www file
     file:
@@ -31,27 +36,32 @@
     vars:
       container_image_list:
         - sebp/lighttpd:latest
-      container_name: lighttpd
+      container_name: "{{ outer_item.name }}"
       container_run_args: >-
         --rm
         -v /tmp/podman-container-systemd:/var/www/localhost/htdocs:Z
         -t
-        -p 8080:80/tcp
+        -p "{{ outer_item.port }}:80/tcp"
       container_firewall_ports:
-        - 8080/tcp
+        - "{{ outer_item.port }}/tcp"
 
     ansible.builtin.include_role:
       name: podman-container-systemd
+    loop: "{{ container_instances }}"
+    loop_control:
+      loop_var: outer_item
 
   - name: Wait for lighttpd to come up
     wait_for:
-      port: 8080
+      port: "{{ item.port }}"
+    loop: "{{ container_instances }}"
     when: container_state == "running"
 
   - name: test if container runs
     get_url:
-      url: http://localhost:8080
+      url: "http://localhost:{{ item.port }}"
       dest: /tmp/podman-container-systemd/index.return.html
+    loop: "{{ container_instances }}"
     register: get_url
     when: container_state == "running"
 


### PR DESCRIPTION
This PR reproduces an error I discovered using this role in a loop since commit 3d03115a0df0d2e1bfae9cb854a8f0688b655733 which removes the following two tasks:

* ensure "{{ service_name }}" is enabled at boot, and systemd reloaded
* name: ensure "{{ service_name }}" is running

and uses handlers more extensively.

The following error is reported:

```
RUNNING HANDLER [podman-container-systemd : start service] *************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Could not find the requested service lighthttpd-2-container-pod-root.service: host"}
```

after running the first iteration (for  lighthttpd-**1**).

The handler in iteration **1** in particular uses the variables from the second/last iteration.

I suspect this is because of the following fact:
> Handlers are made available to the whole play
https://docs.ansible.com/ansible/latest/collections/ansible/builtin/include_role_module.html

I am looking for a solution for this problem. Any suggestions?