### PR TITLE
Folder creation for volumes (containers)

### DIFF
--- a/tasks/create_container_volume.yml
+++ b/tasks/create_container_volume.yml
@@ -14,4 +14,3 @@
     mode: '{{ container_dir_mode|default(omit) }}'
     state: directory
   when: not (_container_folder.stat.isdir is defined and _container_folder.stat.isdir)
-  

--- a/tasks/create_container_volume.yml
+++ b/tasks/create_container_volume.yml
@@ -1,0 +1,17 @@
+---
+- name: Check if {{ item }} is existing
+  become: yes
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  register: _container_folder
+
+- name: Create directory {{ item }} and set permissions
+  become: yes
+  ansible.builtin.file:
+    path: "{{ item }}"
+    owner: "{{ container_dir_owner|default(container_run_as_user) }}"
+    group: "{{ container_dir_group|default(container_run_as_group) }}"
+    mode: '{{ container_dir_mode|default(omit) }}'
+    state: directory
+  when: not (_container_folder.stat.isdir is defined and _container_folder.stat.isdir)
+  

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -187,6 +187,14 @@
       - container_run_as_user != "root"
       - not user_lingering.stat.exists
 
+  - name: "Ensure volume directories exist for {{ container_name }}"
+    ansible.builtin.include_tasks: create_container_volume.yml
+    loop: "{{ container_run_args | regex_findall('-v ([^:]*)') }}"
+    when: 
+      - container_image_list is defined and container_image_list | length == 1
+      - container_run_args is defined and container_run_args | length > 0
+      - container_pod_yaml is undefined
+
   - name: "create systemd service file for container: {{ container_name }}"
     template:
       src: systemd-service-single.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -194,8 +194,6 @@
       owner: root
       group: root
       mode: 0644
-    become: true
-    become_user: "{{ container_run_as_user }}"
     notify:
       - reload systemctl
       - start service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -202,6 +202,8 @@
       owner: root
       group: root
       mode: 0644
+    become: true
+    become_user: "{{ container_run_as_user }}"
     notify:
       - reload systemctl
       - start service


### PR DESCRIPTION
Added folder creation for volumes (containers, not pods) - Pods can use DirectoryOrCreate

First it checks if the folder already exists and if it does, it won't
adjust any permissions. This helps if podman can't manage the
permissions correctly.

It allows for changing the owner and group in case it is needed to set a
specific UID and GID.

It also allows to change the mode.

I added explanations for :U as well, which tells podman to change the
permissions to the container user recursively. This works if the
service inside the container doesn't run with a different user than the
container.