### PR TITLE
authentication information per image

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,17 @@ note that some options apply only to other method.
 
 - ```container_image_list``` - list of container images to run.
   If more than one image is defined, then the containers will be run in a pod.
-- ```container_image_user``` - optional username to use when authenticating
+  It is possible to define it as a dictionary to include authentication information per image, like so:
+``` 
+container_image_list:
+  - image: docker.io/imagename
+    user: exampleuser
+    password: examplepw
+  - image: docker.io/imagename2
+```
+- ```container_image_user``` - optional default username to use when authenticating
   to remote registries
-- ```container_image_password``` - optional password to use when authenticating
+- ```container_image_password``` - optional default password to use when authenticating
   to remote registries
 - ```container_name``` - Identify the container in systemd and podman commands.
   Systemd service file be named container_name--container-pod.service.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -99,6 +99,23 @@
   - name: Check subuid & subgid
     import_tasks: check_subid.yml
 
+  - name: Ensure empty internal variable _container_image_list
+    set_fact:
+      _container_image_list: []
+
+  - name: Convert container_image_list to new form
+    set_fact:
+      _container_image_list: "{{ _container_image_list + [{'image': item}] }}"
+    loop: "{{ container_image_list }}"
+    when: not (container_image_list | selectattr("image", "defined"))
+    no_log: true
+
+  - name: Always use internal variable for container_image_list
+    set_fact:
+      _container_image_list: "{{ container_image_list }}"
+    when: _container_image_list | length == 0
+    no_log: true
+
   - name: running single container, get image Id if it exists and we are root
     # XXX podman doesn't work through sudo for non root users,
     # so skip preload if user
@@ -109,25 +126,24 @@
     register: pre_pull_id
     ignore_errors: true
     when:
-      - container_image_list is defined
-      - container_image_list | length == 1
+      - _container_image_list | length == 1
       - container_run_as_user == 'root'
-    with_items: "{{ container_image_list }}"
+    loop: "{{ _container_image_list | map(attribute='image') }}"
 
   - name: running single container, ensure we have up to date container image
     containers.podman.podman_image:
-      name: "{{ item }}"
+      name: "{{ item.image }}"
       force: true
-      username: "{{ container_image_user | default(omit) }}"
-      password: "{{ container_image_password | default(omit) }}"
+      username: "{{ item.user | default(container_image_user) | default(omit) }}"
+      password: "{{ item.password | default(container_image_password) | default(omit) }}"
     notify: restart service
     become: true
     become_user: "{{ container_run_as_user }}"
     when:
-      - container_image_list is defined
-      - container_image_list | length == 1
+      - _container_image_list | length == 1
       - container_run_as_user == 'root'
-    with_items: "{{ container_image_list }}"
+    loop: "{{ _container_image_list }}"
+    no_log: true
 
   - name: running single container, get image Id if it exists
     command:
@@ -138,21 +154,21 @@
     register: post_pull_id
     ignore_errors: true
     when:
-      - container_image_list is defined
-      - container_image_list | length == 1
+      - _container_image_list | length == 1
       - container_run_as_user == 'root'
-    with_items: "{{ container_image_list }}"
+    loop: "{{ _container_image_list | map(attribute='image') }}"
 
   - name: seems we use several container images, ensure all are up to date
     containers.podman.podman_image:
-      name: "{{ item }}"
+      name: "{{ item.image }}"
       force: true
-      username: "{{ container_image_user | default(omit) }}"
-      password: "{{ container_image_password | default(omit) }}"
+      username: "{{ item.user | default(container_image_user) | default(omit) }}"
+      password: "{{ item.password | default(container_image_password) | default(omit) }}"
     become: true
     become_user: "{{ container_run_as_user }}"
-    when: container_image_list is defined and container_image_list | length > 1
-    with_items: "{{ container_image_list }}"
+    when: _container_image_list | length > 1
+    loop: "{{ _container_image_list }}"
+    no_log: true
 
   - name: Include pod yaml templating
     ansible.builtin.include_tasks: deploy_pod_yaml.yml
@@ -191,7 +207,7 @@
     ansible.builtin.include_tasks: create_container_volume.yml
     loop: "{{ container_run_args | regex_findall('-v ([^:]*)') }}"
     when: 
-      - container_image_list is defined and container_image_list | length == 1
+      - _container_image_list | length == 1
       - container_run_args is defined and container_run_args | length > 0
       - container_pod_yaml is undefined
 
@@ -209,7 +225,7 @@
       - start service
       - enable service
     register: service_file
-    when: container_image_list is defined and container_image_list | length == 1
+    when: _container_image_list | length == 1
 
   - name: "create systemd service file for pod: {{ container_name }}"
     template:
@@ -223,7 +239,7 @@
       - start service
       - enable service
     register: service_file
-    when: container_image_list is defined and container_image_list | length > 1
+    when: _container_image_list | length > 1
 
   - name: "ensure {{ service_name }} is restarted due config change"
     debug: msg="config has changed:"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -102,18 +102,21 @@
   - name: Ensure empty internal variable _container_image_list
     set_fact:
       _container_image_list: []
+    changed_when: false
 
   - name: Convert container_image_list to new form
     set_fact:
       _container_image_list: "{{ _container_image_list + [{'image': item}] }}"
     loop: "{{ container_image_list }}"
     when: not (container_image_list | selectattr("image", "defined"))
+    changed_when: false
     no_log: true
 
   - name: Always use internal variable for container_image_list
     set_fact:
       _container_image_list: "{{ container_image_list }}"
     when: _container_image_list | length == 0
+    changed_when: false
     no_log: true
 
   - name: running single container, get image Id if it exists and we are root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -145,6 +145,7 @@
     when:
       - _container_image_list | length == 1
       - container_run_as_user == 'root'
+      - not (item.image | regex_search ('^localhost/.*'))
     loop: "{{ _container_image_list }}"
     no_log: true
 
@@ -169,7 +170,9 @@
       password: "{{ item.password | default(container_image_password) | default(omit) }}"
     become: true
     become_user: "{{ container_run_as_user }}"
-    when: _container_image_list | length > 1
+    when:
+      - _container_image_list | length > 1
+      - not (item.image | regex_search ('^localhost/.*'))
     loop: "{{ _container_image_list }}"
     no_log: true
 

--- a/templates/systemd-service-single.j2
+++ b/templates/systemd-service-single.j2
@@ -29,7 +29,7 @@ User={{ container_run_as_user }}
 ExecStart=/usr/bin/podman run --name {{ container_name }} \
   {{ container_run_args }} \
   --conmon-pidfile  {{ pidfile }} --cidfile {{ cidfile }} \
-  {{ container_image_list | first }} {% if container_cmd_args is defined %} \
+  {{ _container_image_list | map(attribute='image') | first }} {% if container_cmd_args is defined %} \
   {{ container_cmd_args }} {% endif %}
 
 ExecStop=/usr/bin/sh -c "/usr/bin/podman stop -t "{{ container_stop_timeout }}" `cat {{ cidfile }}`"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,3 +7,4 @@ pidfile: "{{ cidpid_base }}pid"
 
 # kubeval
 kubeval_url: "https://github.com/instrumenta/kubeval/releases/latest"
+


### PR DESCRIPTION
Added the possibility to define user and password information per image. It will also hide the secret information now in the logs. I wrote it backwards compatible, so if the container_image_list is still a list and not in the new dictionary format, then it will be created as a dictionary and used internally. The variables container_image_user and container_image_password will be used as a default value now if they are defined and if the image has no other authentication information defined.