### PR TITLE
container_image_list can be a string

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -101,7 +101,7 @@
   - name: Convert container_image_list to new form
     set_fact:
       _container_image_list: "{{ _container_image_list + [{'image': item}] }}"
-    loop: "{{ container_image_list }}"
+    with_items: "{{ container_image_list }}"
     when: not (container_image_list | selectattr("image", "defined"))
     changed_when: false
     no_log: true


### PR DESCRIPTION
Until now `container_image_list` had to be a list as it is required for the `loop` parameter.

`with_items` works with string and list.

After this PR the following is possible and handy if use are using the role for a single image:

```yaml
container_image_list: "hello-world" # Or any other image
```

But it is still possible

```yaml
container_image_list: 
  - "hello-world" # Or any other image
```

Or it is also the following possible, but then the relevant task is skipped

```yaml
container_image_list: 
  - image: "hello-world" # Or any other image
```