### PR TITLE
Use systemd task instead handler

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -8,14 +8,3 @@
   ansible.builtin.systemd:
     daemon_reload: true
     scope: "{{ systemd_scope }}"
-
-- name: Restart service
-  become: true
-  become_user: "{{ container_run_as_user }}"
-  environment:
-    XDG_RUNTIME_DIR: "{{ xdg_runtime_dir }}"
-  ansible.builtin.systemd:
-    name: "{{ service_name }}"
-    scope: "{{ systemd_scope }}"
-    state: restarted
-    enabled: true

--- a/tasks/deploy_pod_yaml.yml
+++ b/tasks/deploy_pod_yaml.yml
@@ -37,22 +37,12 @@
         remote_src: yes
         keep_newer: yes  
 
-    - name: Deploy container configuration
-      ansible.builtin.template:
-        src: "{{ container_pod_yaml_template }}"
-        dest: "{{ container_pod_yaml }}"
-        owner: "{{ container_run_as_user }}"
-        group: "{{ container_run_as_group }}"
-        mode: '0640'
-        validate: /usr/local/bin/kubeval %s
-      notify: Restart service
-    
-- name: Container-pod-yaml without validation
+- name: Deploy container configuration
   ansible.builtin.template:
     src: "{{ container_pod_yaml_template }}"
     dest: "{{ container_pod_yaml }}"
     owner: "{{ container_run_as_user }}"
     group: "{{ container_run_as_group }}"
     mode: '0640'
-  notify: Restart service
-  when: not container_pod_yaml_template_validation
+    validate: "{{ container_pod_yaml_template_validation | ternary('/usr/local/bin/kubeval %s', omit) }}"
+  register: container_pod_yaml_copy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -90,9 +90,10 @@
     - name: Check subuid & subgid
       ansible.builtin.import_tasks: check_subid.yml
 
-    - name: Ensure empty internal variable _container_image_list
+    - name: Set internal variables
       ansible.builtin.set_fact:
         _container_image_list: []
+        _service_systemd_state: started
       changed_when: false
 
     - name: Convert container_image_list to new form
@@ -116,7 +117,6 @@
         force: true
         username: "{{ item.user | default(container_image_user) | default(omit) }}"
         password: "{{ item.password | default(container_image_password) | default(omit) }}"
-      notify: Restart service
       become: true
       become_user: "{{ container_run_as_user }}"
       when:
@@ -125,6 +125,7 @@
         - not (item.image | regex_search ('^localhost/.*'))
       loop: "{{ _container_image_list }}"
       no_log: true
+      register: podman_image_pull
 
     - name: Seems we use several container images, ensure all are up to date
       containers.podman.podman_image:
@@ -195,10 +196,27 @@
         group: "{{ service_files_group }}"
         mode: "{{ service_files_mode }}"
       become: true
-      notify:
-        - Reload systemctl
-        - Restart service
       register: service_file
+
+    - name: Set variable to restart service
+      ansible.builtin.set_fact:
+        _service_systemd_state: restarted
+      when: >-
+        podman_image_pull is changed 
+        or service_file is changed 
+        or (container_pod_yaml_copy is defined and container_pod_yaml_copy is changed)
+
+    - name: Ensure service is enabled and {{ _service_systemd_state }}
+      become: true
+      become_user: "{{ container_run_as_user }}"
+      environment:
+        XDG_RUNTIME_DIR: "{{ xdg_runtime_dir }}"
+      ansible.builtin.systemd:
+        name: "{{ service_name }}"
+        scope: "{{ systemd_scope }}"
+        state: "{{ _service_systemd_state }}"
+        enabled: true
+        daemon_reload: "{{ service_file is changed }}"
 
     - name: Ensure auto update is running for images
       become: true
@@ -304,7 +322,3 @@
       path: "{{ container_pod_yaml }}"
       state: absent
     when: container_pod_yaml is defined
-
-
-- name: Force all notified handlers to run at this point
-  ansible.builtin.meta: flush_handlers


### PR DESCRIPTION
Requires #72 to be merged first!

I moved the restart service handler into the main as task because:
- on a second run without changes ansible ensure the service is running (idempotent)
- if the service was stopped by any reason (manual, crash) it will be started again

I know you have said in https://github.com/ikke-t/podman-container-systemd/issues/38#issuecomment-881941710 that anyone must verify that the service is running correctly afterwards but I think so we can ensure that the service was started also on mutliple runs