### PR TITLE
container_run_args can be a list

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ container_image_list:
 - ```container_name``` - Identify the container in systemd and podman commands.
   Systemd service file be named container_name--container-pod.service. This can be overwritten with service_name.
 - ```container_run_args``` - Anything you pass to podman, except for the name
-  and image while running single container. Not used for pod.
+  and image while running single container. Not used for pod. Can be a string or a list of strings.
 - ```container_cmd_args``` - Any command and arguments passed to podman-run after specifying the image name. Not used for pod.
 - ```container_run_as_user``` - Which user should systemd run container as.
   Defaults to root.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -94,6 +94,7 @@
       ansible.builtin.set_fact:
         _container_image_list: []
         _service_systemd_state: started
+        _container_run_args: "{{ container_run_args | default('') }}"
       changed_when: false
 
     - name: Convert container_image_list to new form
@@ -174,6 +175,14 @@
         - container_run_as_user != "root"
         - not user_lingering.stat.exists
 
+    - name: Convert container_run_args list to string
+      ansible.builtin.set_fact:
+        _container_run_args: "{{ _container_run_args | join(' ') }}"
+      when:
+        - _container_run_args is iterable
+        - _container_run_args is not string
+        - _container_run_args is not mapping
+
     - name: Ensure volume directories exist for {{ container_name }}
       ansible.builtin.file:
         path: "{{ item }}"
@@ -182,10 +191,10 @@
         mode: "{{ container_dir_mode | default(omit) }}"
         state: directory
       become: true
-      loop: "{{ container_run_args | regex_findall('-v ([^:]*)') }}"
+      loop: "{{ _container_run_args | regex_findall('-v ([^:]*)') }}"
       when: 
         - _container_image_list | length == 1
-        - container_run_args is defined and container_run_args | length > 0
+        - _container_run_args | length > 0
         - container_pod_yaml is undefined
 
     - name: Create systemd service file for {{ container_name }}

--- a/templates/systemd-service-single.j2
+++ b/templates/systemd-service-single.j2
@@ -28,7 +28,7 @@ User={{ container_run_as_user }}
 {% endif %}
 
 ExecStart=/usr/bin/podman run --name {{ container_name }} \
-  {{ container_run_args }} \
+  {{ _container_run_args }} \
   --conmon-pidfile  {{ pidfile }} --cidfile {{ cidfile }} \
   {{ _container_image_list | map(attribute='image') | first }} {% if container_cmd_args is defined %} \
   {{ container_cmd_args }} {% endif %}


### PR DESCRIPTION
I implemented it as now you can comment out parts of the container_run_args for example for debugging

example:
```yaml
- vars:
    container_image_list: 
      - sebp/lighttpd:latest
    container_name: lighttpd
    container_run_args:
      - --rm
      - -v /tmp/podman-container-systemd:/var/www/localhost/htdocs:Z,U
      # - --label "io.containers.autoupdate=image"
      - -p 8080:80
  ansible.builtin.include_role:
    name: podman-container-systemd
```

Motivation was that I had comment out similar as #38