### PR TITLE
fix regex not accounting for double quotes

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -191,7 +191,7 @@
         mode: "{{ container_dir_mode | default(omit) }}"
         state: directory
       become: true
-      loop: "{{ _container_run_args | regex_findall('-v ([^:]*)') }}"
+      loop: "{{ _container_run_args | regex_findall('-v \"*([^:]*)') }}"
       when: 
         - _container_image_list | length == 1
         - _container_run_args | length > 0


### PR DESCRIPTION
My use case is using jinja variables in the path and therefore needed to include double quotes around the path.  The regex did not account for this scenario.  I added checking for 0 or more quotes in the string.